### PR TITLE
Use cdn for utterances

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -40,6 +40,9 @@
       utterances.setAttribute('issue-term', 'title');
       utterances.setAttribute('crossorigin', 'anonymous');
       utterances.setAttribute('async', true);
+      <% if (theme.dark){ %>
+      utterances.setAttribute('theme', 'github-dark');
+      <% } %>
       if (utterances_container){
         utterances_container.appendChild(utterances);
       }

--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -35,7 +35,7 @@
     (function() {
       var utterances = document.createElement('script');
       var utterances_container = document.getElementById('utterances_container');
-      utterances.src='https://utteranc.es/client.js'
+      utterances.src='https://cdn.jsdelivr.net/npm/utterances-npmjs/dist/client.min.js'
       utterances.setAttribute('repo', '<%= theme.utterances.repo %>');
       utterances.setAttribute('issue-term', 'title');
       utterances.setAttribute('crossorigin', 'anonymous');


### PR DESCRIPTION
Continue from previous PR https://github.com/geekplux/hexo-theme-typing/pull/28, I managed to mirror the library to cdn. Most of the features still depend on `api.utteranc.es`, but at least the `client.js` can be offloaded to cdn.

Utterances also support dark theme.

Test pages:
https://weyusi.github.io/hexo-testing/2018/10/06/fancybox-test/
https://weyusi.github.io/hexo-testing/2018/10/05/hello-world/