### PR TITLE
refactor: move fancybox css to head

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -79,7 +79,6 @@
 <%- js('https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js') %>
 
 <% if (theme.fancybox){ %>
-  <%- css('https://cdn.jsdelivr.net/npm/@fancyapps/fancybox@3/dist/jquery.fancybox.min.css') %>
   <%- js('https://cdn.jsdelivr.net/npm/@fancyapps/fancybox@3/dist/jquery.fancybox.min.js') %>
 <% } %>
 

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -33,4 +33,7 @@
   <% if (theme.icons){ %>
   <%- css('https://cdn.jsdelivr.net/npm/fork-awesome@1/css/fork-awesome.min.css') %>
   <% } %>
+  <% if (theme.fancybox){ %>
+    <%- css('https://cdn.jsdelivr.net/npm/@fancyapps/fancybox@3/dist/jquery.fancybox.min.css') %>
+  <% } %>
 </head>


### PR DESCRIPTION
css file is [usually in `<head>`](https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#Applying_CSS_and_JavaScript_to_HTML), 
fancybox [setup guide](https://fancyapps.com/fancybox/3/docs/#setup) also use that convention.