### PR TITLE
fix: use main config's language option

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,3 @@
-# Lang
-language: en
-
 # Dark Mode
 dark: false
 

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= theme.language %>">
+<html lang="<%= config.language %>">
 <%- partial('_partial/head') %>
   <% if (is_home()) { %>
     <% if (theme.dark) { %>


### PR DESCRIPTION
the current setting is a duplicate of the main config's.
https://github.com/hexojs/hexo/pull/3654
https://github.com/hexojs/hexo-starter/pull/12

This PR shouldn't affect the [languages](https://github.com/geekplux/hexo-theme-typing/tree/master/languages) folder (based on preliminary testing).