### PR TITLE
feat: support rss2 and multi-format feed

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -20,8 +20,18 @@
   <title><% if (title){ %><%= title %> | <% } %><%= config.title %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
-  <% if (theme.rss){ %>
-    <link rel="alternate" href="<%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">
+  <% if (config.feed) { %>
+    <% if (config.feed.type.length && config.feed.path.length) { %>
+      <% if (typeof config.feed.type === 'string' )) { %>
+        <link rel="alternate" type="application/<%- config.feed.type.replace(/2$/, '') %>+xml" title="<%= config.title %>" href="<%- url_for(config.feed.path) %>">
+      <% } else { %>
+        <% for (const i in config.feed.type) { %>
+          <link rel="alternate" type="application/<%- config.feed.type[i].replace(/2$/, '') %>+xml" title="<%= config.title %>" href="<%- url_for(config.feed.path[i]) %>">
+        <% } %>
+      <% } %>
+    <% } %>
+  <% } else if (theme.rss) { %>
+    <link rel="alternate" href="<%- url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml">
   <% } %>
   <% if (theme.favicon){ %>
     <link rel="icon" href="<%- theme.favicon %>">


### PR DESCRIPTION
hexo-generator-feed has long support generating RSS2-formatted feed (in addition to the default Atom), so this PR address that.

[hexo-generator-feed](https://github.com/hexojs/hexo-generator-feed) [2.1+](https://github.com/hexojs/hexo-generator-feed/releases/tag/2.1.0) now supports generating both atom and rss2 at the same time (if enabled, currently still defaults to atom-only).

2.1+ also insert the [autodiscovery](http://www.rssboard.org/rss-autodiscovery) tag by default, so it's no longer necessary for theme to insert it. However, user might be using older version, so it's up to the theme dev whether to support it or not. There is also a slight performance advantage if theme inserts it, instead of plugin doing it.

More details: https://github.com/hexojs/hexo-theme-unit-test/pull/25