### PR TITLE
feat: hide mobile menu when click outside

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -2,7 +2,7 @@
   <nav class="mobile-nav">
     <h1 class="nickname"><%= theme.nickname %></h1>
     <ul class="mobile-nav-menu">
-      <label for="mobile-menu-toggle"><a>&#9776; Menu</a></label>
+      <label for="mobile-menu-toggle"><a id="menu-button">&#9776; Menu</a></label>
       <input type="checkbox" id="mobile-menu-toggle"/>
       <ul class="mobile-nav-link">
         <% for (var i in theme.menu){ %>

--- a/source/js/typing.js
+++ b/source/js/typing.js
@@ -59,6 +59,21 @@
 			  });
 			  $('#DonateText,#donateBox,#github').removeClass('blur');
 		  },600);
-    });
+		});
+
+		// Hide mobile menu when click outside of the menu
+		$(document).click(function(event) {
+			const mainNavDisplay = $('.main-nav').css('display');
+			const mobileNav = $('.mobile-nav-link');
+			const menuBtn = $('#menu-button');
+			const mobileToggle = $('#mobile-menu-toggle');
+			const isClickedOutside = !$(event.target).is(mobileNav);
+
+			if (mainNavDisplay !== 'none' || $(event.target).is(menuBtn) || $(event.target).is(mobileToggle) || mobileToggle.prop('checked') === false) return;
+
+			if (isClickedOutside) {
+				mobileToggle.prop('checked', false);
+			}
+		});
   });
 })(jQuery)


### PR DESCRIPTION
![mobile-menu](https://user-images.githubusercontent.com/43627182/79064810-277ec680-7ceb-11ea-9d07-3107b3ad33df.png)

Make it easier to close the mobile menu.

When mobile menu is displayed, if user click/tap on outside (like **X**) area, mobile menu will be closed. No effect if tap within the menu (like **Y**) area.

This PR uses jQuery; for vanilla JS implementation,

``` js
document.addEventListener('click', (event) => {
  const mainNavDisplay = window.getComputedStyle(document.getElementsByClassName('main-nav')[0]).getPropertyValue('display')
  const mobileNav = document.getElementsByClassName('mobile-nav-link')[0]
  const mobileToggle = document.getElementById('mobile-menu-toggle')
  const isClickedOutside = !mobileNav.contains(evt.target)

  // Exit if not in mobile view or menu button is clicked
  // Menu button click triggers `menu-button` and `mobile-menu-toggle`
  if (mainNavDisplay !== 'none' || event.target.id === 'menu-button' || event.target.id === 'mobile-menu-toggle') return

  if (isClickedOutside) {
    mobileToggle.checked = false
  }
}, false)
```