### PR TITLE
chore(devDeps): update postcss-cli to version 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,11 @@
   "devDependencies": {
     "autoprefixer": "^9.2.1",
     "cssnano": "^4.1.5",
-    "postcss-cli": "^6.0.1",
+    "postcss-cli": "^7.1.0",
     "postcss-import": "^12.0.0",
     "precss": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
[v7.0](https://github.com/postcss/postcss-cli/releases/tag/7.0.0) onwards require Node >=10

I ran `make css` and found no changes to "typing.css" file.