### PR TITLE
refactor: utilize helpers

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -7,7 +7,7 @@
     <% if (theme.icons){ %>
       <ul class="footer-links">
         <% for (var key in theme.links) { %>
-          <li><a href="<%= theme.links[key] %>"><span class="fa fa-<%= key %>"></span></a></li>
+          <li><a href="<%- url_for(theme.links[key]) %>"><span class="fa fa-<%= key %>"></span></a></li>
         <% } %>
       </ul>
 	  <% } %>
@@ -19,7 +19,7 @@
       <% if (theme.icons){ %>
         <ul class="footer-links">
           <% for (var key in theme.links) { %>
-            <li><a href="<%= theme.links[key] %>"><span class="fa fa-<%= key %>"></span></a></li>
+            <li><a href="<%- url_for(theme.links[key]) %>"><span class="fa fa-<%= key %>"></span></a></li>
           <% } %>
         </ul>
 	    <% } %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -26,7 +26,7 @@
     <%- feed_tag(theme.rss) %>
   <% } %>
   <% if (theme.favicon){ %>
-    <link rel="icon" href="<%- theme.favicon %>">
+    <%- favicon_tag(theme.favicon) %>
   <% } %>
   <%- css('css/typing') %>
   <%- css('css/donate') %>

--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -21,17 +21,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <%- open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id}) %>
   <% if (config.feed) { %>
-    <% if (config.feed.type.length && config.feed.path.length) { %>
-      <% if (typeof config.feed.type === 'string' ) { %>
-        <link rel="alternate" type="application/<%- config.feed.type.replace(/2$/, '') %>+xml" title="<%= config.title %>" href="<%- url_for(config.feed.path) %>">
-      <% } else { %>
-        <% for (const i in config.feed.type) { %>
-          <link rel="alternate" type="application/<%- config.feed.type[i].replace(/2$/, '') %>+xml" title="<%= config.title %>" href="<%- url_for(config.feed.path[i]) %>">
-        <% } %>
-      <% } %>
-    <% } %>
+    <%- feed_tag() %>
   <% } else if (theme.rss) { %>
-    <link rel="alternate" href="<%- url_for(theme.rss) %>" title="<%= config.title %>" type="application/atom+xml">
+    <%- feed_tag(theme.rss) %>
   <% } %>
   <% if (theme.favicon){ %>
     <link rel="icon" href="<%- theme.favicon %>">

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -13,9 +13,9 @@
       <% for (var key in theme.links) { %>
         <li>
 	  <% if (theme.icons){ %>
-            <a href="<%= theme.links[key] %>"><span class="fa fa-<%= key %>"></span></a>
+            <a href="<%- url_for(theme.links[key]) %>"><span class="fa fa-<%= key %>"></span></a>
 	  <% } else { %>
-	    <a href="<%= theme.links[key] %>"><%= key %></a>
+	    <a href="<%- url_for(theme.links[key]) %>"><%= key %></a>
 	  <% } %>
         </li>
       <% } %>


### PR DESCRIPTION
[`url_for()`](https://hexo.io/docs/helpers#url-for) automatically prepends [`config.root`](https://hexo.io/docs/configuration#URL) to internal links, without resorting to `<%- config.root + path %>`. See https://github.com/hexojs/hexo-util/pull/217

Other helpers `feed_tag()` and `favicon_tag()` are also utilized.